### PR TITLE
Add tasks to clean unconfigured P2s

### DIFF
--- a/tasks/ipsecphase1.yml
+++ b/tasks/ipsecphase1.yml
@@ -98,7 +98,7 @@
     path: "{{ local_config_path }}"
     xpath: "/opnsense/ipsec/phase2[ikeid='{{ ikeid }}' and uniqid='{{ item.uniqid }}']"
     state: absent
-    pretty_print: yes
+    pretty_print: true
   when: item.uniqid not in ipsecphasevar.phase2
   with_items: "{{ phase2ikeiduniqid_all.matches }}"
 

--- a/tasks/ipsecphase1.yml
+++ b/tasks/ipsecphase1.yml
@@ -84,4 +84,22 @@
   loop_control:
     loop_var: p2
 
+- name: "IPSec ike phase2 search configured uniqid for ikeid {{ ikeid }}"
+  delegate_to: localhost
+  community.general.xml:
+    path: "{{ local_config_path }}"
+    xpath: "/opnsense/ipsec/phase2[ikeid='{{ ikeid }}']/uniqid"
+    content: text
+  register: phase2ikeiduniqid_all
+
+- name: "IPSec ike phase2 cleanup for ikeid {{ ikeid }}"
+  delegate_to: localhost
+  community.general.xml:
+    path: "{{ local_config_path }}"
+    xpath: "/opnsense/ipsec/phase2[ikeid='{{ ikeid }}' and uniqid='{{ item.uniqid }}']"
+    state: absent
+    pretty_print: yes
+  when: item.uniqid not in ipsecphasevar.phase2
+  with_items: "{{ phase2ikeiduniqid_all.matches }}"
+
 ...


### PR DESCRIPTION
https://github.com/Rosa-Luxemburgstiftung-Berlin/ansible-opnsense/issues/21

The expected result is that after the P2 configuration loop `loop IPSec ike phase2 for ikeid {{ ikeid }}`, it will search for all P2s present in config file for the respective `ikeid`, and then remove the ones that are not present in the host variables, based on `uniqid`

We have already used these 2 tasks in our prod env successfully. Unfortunately, i dont have the time atm to look into building tests for this.
